### PR TITLE
1205626-css class selector updated

### DIFF
--- a/widget/widgetAssets/css/cardView.css
+++ b/widget/widgetAssets/css/cardView.css
@@ -90,12 +90,14 @@
 }
 
 #main-view-template {
-    & .queue-card-wrapper {
-        .panel-heading {
-            height: 0px;
-            border-left: none !important;
-            border-right: none !important;
-            border-bottom: none !important;
+    & .filterContainer {
+        & .queue-card-wrapper {
+            .panel-heading {
+                height: 0px;
+                border-left: none !important;
+                border-right: none !important;
+                border-bottom: none !important;
+            }
         }
     }
 }


### PR DESCRIPTION
Mantis -[1205626]

[Regression]
FSR Build: 7.6.4-5608
2. Feed Datasets in TIM SP does not render in Space/Dark theme, however. visible in Light theme.

Fix - 
css class selector updated by adding .filterContainer class name

<img width="1873" height="672" alt="Screenshot 2025-09-23 at 4 57 44 PM" src="https://github.com/user-attachments/assets/d13812f6-cec8-4614-8ae5-6978e4c9dd83" />

Doc Impact - NA 
